### PR TITLE
Refactor haplotypes functions to support Af1 -- set default phasing analysis

### DIFF
--- a/malariagen_data/af1.py
+++ b/malariagen_data/af1.py
@@ -112,6 +112,8 @@ class Af1(AnophelesDataResource):
     _site_annotations_zarr_path = SITE_ANNOTATIONS_ZARR_PATH
     _cohorts_analysis = None
     _site_filters_analysis = None
+    phasing_analysis_ids = ("funestus",)
+    _default_phasing_analysis = "funestus"
 
     def __init__(
         self,

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -145,6 +145,8 @@ class Ag3(AnophelesDataResource):
     _h1x_gwss_cache_name = H1X_GWSS_CACHE_NAME
     _default_site_mask = DEFAULT_SITE_MASK
     _site_annotations_zarr_path = SITE_ANNOTATIONS_ZARR_PATH
+    phasing_analysis_ids = ("gamb_colu_arab", "gamb_colu", "arab")
+    _default_phasing_analysis = "gamb_colu_arab"
 
     def __init__(
         self,


### PR DESCRIPTION
Hi @leehart, this PR sets a default value for the `analysis` parameter in all methods that use haplotypes. 

The main motivation is that, for funestus, there is only one possible value for this parameter, and so asking the user to provide this every time is a waste of their time and annoying. 

Also, for Ag, it is reasonable to set a default value (gamb_colu_arab) which works reasonably well for all samples - power users can then use something different if they know what they're doing.