### PR TITLE
Refactor haplotypes functions to support Af1 -- suggestions part 2

### DIFF
--- a/malariagen_data/af1.py
+++ b/malariagen_data/af1.py
@@ -108,6 +108,7 @@ class Af1(AnophelesDataResource):
     _h12_calibration_cache_name = H12_CALIBRATION_CACHE_NAME
     _h12_gwss_cache_name = H12_GWSS_CACHE_NAME
     _h1x_gwss_cache_name = H1X_GWSS_CACHE_NAME
+    site_mask_ids = ("funestus",)
     _default_site_mask = DEFAULT_SITE_MASK
     _site_annotations_zarr_path = SITE_ANNOTATIONS_ZARR_PATH
     _cohorts_analysis = None
@@ -264,14 +265,6 @@ class Af1(AnophelesDataResource):
         parent_name = parent
 
         return parent_name
-
-    def _site_mask_ids(self):
-        if self._site_filters_analysis == "dt_20200416":
-            return ["funestus"]
-        elif self._site_filters_analysis == "sc_20220908":
-            return ["funestus"]
-        else:
-            raise ValueError
 
     def genome_features(
         self, region=None, attributes=("ID", "Parent", "Note", "description")

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -143,6 +143,7 @@ class Ag3(AnophelesDataResource):
     _h12_calibration_cache_name = H12_CALIBRATION_CACHE_NAME
     _h12_gwss_cache_name = H12_GWSS_CACHE_NAME
     _h1x_gwss_cache_name = H1X_GWSS_CACHE_NAME
+    site_mask_ids = ("gamb_colu_arab", "gamb_colu", "arab")
     _default_site_mask = DEFAULT_SITE_MASK
     _site_annotations_zarr_path = SITE_ANNOTATIONS_ZARR_PATH
     phasing_analysis_ids = ("gamb_colu_arab", "gamb_colu", "arab")
@@ -498,12 +499,6 @@ class Ag3(AnophelesDataResource):
             parent_name = rec_parent["Name"]
 
         return parent_name
-
-    def _site_mask_ids(self):
-        if self._site_filters_analysis == "dt_20200416":
-            return "gamb_colu_arab", "gamb_colu", "arab"
-        else:
-            raise ValueError
 
     def cross_metadata(self):
         """Load a dataframe containing metadata about samples in colony crosses,
@@ -2209,7 +2204,7 @@ class Ag3(AnophelesDataResource):
     ):
         debug = self._log.debug
 
-        for site_mask in self._site_mask_ids():
+        for site_mask in self.site_mask_ids:
             site_filters_vcf_url = f"gs://vo_agam_release/v3/site_filters/{self._site_filters_analysis}/vcf/{site_mask}/{contig}_sitefilters.vcf.gz"  # noqa
             debug(site_filters_vcf_url)
             track_config = {

--- a/malariagen_data/ag3.py
+++ b/malariagen_data/ag3.py
@@ -468,7 +468,7 @@ class Ag3(AnophelesDataResource):
 
         """
 
-        sample_sets = self._prep_sample_sets_arg(sample_sets=sample_sets)
+        sample_sets = self._prep_sample_sets_param(sample_sets=sample_sets)
 
         # concatenate multiple sample sets
         dfs = [self._read_species_calls(sample_set=s) for s in sample_sets]
@@ -689,7 +689,7 @@ class Ag3(AnophelesDataResource):
         debug = self._log.debug
 
         debug("normalise parameters")
-        sample_sets = self._prep_sample_sets_arg(sample_sets=sample_sets)
+        sample_sets = self._prep_sample_sets_param(sample_sets=sample_sets)
         region = self.resolve_region(region)
         if isinstance(region, Region):
             region = [region]
@@ -1081,7 +1081,7 @@ class Ag3(AnophelesDataResource):
         # CNV alleles have unknown start or end coordinates.
 
         debug("normalise parameters")
-        sample_sets = self._prep_sample_sets_arg(sample_sets=sample_sets)
+        sample_sets = self._prep_sample_sets_param(sample_sets=sample_sets)
         if isinstance(contig, str):
             contig = [contig]
 
@@ -2296,7 +2296,7 @@ class Ag3(AnophelesDataResource):
         debug = self._log.debug
 
         debug("normalise parameters")
-        sample_sets = self._prep_sample_sets_arg(sample_sets=sample_sets)
+        sample_sets = self._prep_sample_sets_param(sample_sets=sample_sets)
 
         debug("access SNP calls and concatenate multiple sample sets and/or regions")
         ly = []

--- a/malariagen_data/anopheles.py
+++ b/malariagen_data/anopheles.py
@@ -3003,7 +3003,7 @@ class AnophelesDataResource(ABC):
         self,
         sample,
         region,
-        site_mask="default",
+        site_mask=DEFAULT,
         window_size=20_000,
         sample_set=None,
         y_max=0.03,
@@ -3087,7 +3087,7 @@ class AnophelesDataResource(ABC):
         self,
         sample,
         region,
-        site_mask="default",
+        site_mask=DEFAULT,
         window_size=20_000,
         sample_set=None,
         y_max=0.03,
@@ -3221,7 +3221,7 @@ class AnophelesDataResource(ABC):
         debug = self._log.debug
 
         region = self.resolve_region(region)
-        if site_mask == "default":
+        if site_mask == DEFAULT:
             site_mask = self._default_site_mask
 
         debug("access sample metadata, look up sample")
@@ -3266,7 +3266,7 @@ class AnophelesDataResource(ABC):
         sample,
         region,
         window_size=20_000,
-        site_mask="default",
+        site_mask=DEFAULT,
         sample_set=None,
         phet_roh=0.001,
         phet_nonroh=(0.003, 0.01),
@@ -3416,7 +3416,7 @@ class AnophelesDataResource(ABC):
         sample,
         region,
         window_size=20_000,
-        site_mask="default",
+        site_mask=DEFAULT,
         sample_set=None,
         phet_roh=0.001,
         phet_nonroh=(0.003, 0.01),
@@ -3837,7 +3837,7 @@ class AnophelesDataResource(ABC):
         thin_offset=0,
         sample_sets=None,
         sample_query=None,
-        site_mask="default",
+        site_mask=DEFAULT,
         min_minor_ac=2,
         max_missing_an=0,
         n_components=20,
@@ -3897,7 +3897,7 @@ class AnophelesDataResource(ABC):
         # invalidate any previously cached data
         name = self._pca_results_cache_name
 
-        if site_mask == "default":
+        if site_mask == DEFAULT:
             site_mask = self._default_site_mask
 
         debug("normalize params for consistent hash value")
@@ -3942,7 +3942,7 @@ class AnophelesDataResource(ABC):
         region,
         sample_sets=None,
         sample_query=None,
-        site_mask="default",
+        site_mask=DEFAULT,
         cohort_size=None,
         sizing_mode=DEFAULT_GENOME_PLOT_SIZING_MODE,
         width=DEFAULT_GENOME_PLOT_WIDTH,
@@ -3994,7 +3994,7 @@ class AnophelesDataResource(ABC):
         """
         debug = self._log.debug
 
-        if site_mask == "default":
+        if site_mask == DEFAULT:
             site_mask = self._default_site_mask
 
         import bokeh.layouts as bklay
@@ -4058,7 +4058,7 @@ class AnophelesDataResource(ABC):
         region,
         sample_sets=None,
         sample_query=None,
-        site_mask="default",
+        site_mask=DEFAULT,
         cohort_size=None,
         sizing_mode=DEFAULT_GENOME_PLOT_SIZING_MODE,
         width=DEFAULT_GENOME_PLOT_WIDTH,
@@ -4110,7 +4110,7 @@ class AnophelesDataResource(ABC):
         """
         debug = self._log.debug
 
-        if site_mask == "default":
+        if site_mask == DEFAULT:
             site_mask = self._default_site_mask
 
         import bokeh.models as bkmod
@@ -5250,7 +5250,7 @@ class AnophelesDataResource(ABC):
         cohort1_query,
         cohort2_query,
         sample_sets=None,
-        site_mask="default",
+        site_mask=DEFAULT,
         cohort_size=30,
         random_seed=42,
     ):
@@ -5292,7 +5292,7 @@ class AnophelesDataResource(ABC):
         # invalidate any previously cached data
         name = self._fst_gwss_results_cache_name
 
-        if site_mask == "default":
+        if site_mask == DEFAULT:
             site_mask = self._default_site_mask
 
         params = dict(
@@ -6277,7 +6277,7 @@ class AnophelesDataResource(ABC):
         cohort1_query,
         cohort2_query,
         sample_sets=None,
-        site_mask="default",
+        site_mask=DEFAULT,
         cohort_size=30,
         random_seed=42,
         title=None,
@@ -6395,7 +6395,7 @@ class AnophelesDataResource(ABC):
         cohort1_query,
         cohort2_query,
         sample_sets=None,
-        site_mask="default",
+        site_mask=DEFAULT,
         cohort_size=30,
         random_seed=42,
         title=None,

--- a/malariagen_data/anopheles.py
+++ b/malariagen_data/anopheles.py
@@ -475,7 +475,7 @@ class AnophelesDataResource(ABC):
             sample_query = np.nonzero(loc_samples)[0].tolist()
         params = dict(
             region=self.resolve_region(region).to_dict(),
-            sample_sets=self._prep_sample_sets_arg(sample_sets=sample_sets),
+            sample_sets=self._prep_sample_sets_param(sample_sets=sample_sets),
             sample_query=sample_query,
             site_mask=site_mask,
             site_class=site_class,
@@ -1167,7 +1167,7 @@ class AnophelesDataResource(ABC):
 
         return df.copy()
 
-    def _prep_sample_sets_arg(self, *, sample_sets):
+    def _prep_sample_sets_param(self, *, sample_sets):
         """Common handling for the `sample_sets` parameter. For convenience, we
         allow this to be a single sample set, or a list of sample sets, or a
         release identifier, or a list of release identifiers."""
@@ -1194,7 +1194,7 @@ class AnophelesDataResource(ABC):
             for s in sample_sets:
 
                 # make a recursive call to handle the case where s is a release identifier
-                sp = self._prep_sample_sets_arg(sample_sets=s)
+                sp = self._prep_sample_sets_param(sample_sets=s)
 
                 # make sure we end up with a flat list of sample sets
                 if isinstance(sp, str):
@@ -1292,7 +1292,7 @@ class AnophelesDataResource(ABC):
 
         """
 
-        sample_sets = self._prep_sample_sets_arg(sample_sets=sample_sets)
+        sample_sets = self._prep_sample_sets_param(sample_sets=sample_sets)
         cache_key = tuple(sample_sets)
 
         try:
@@ -1638,7 +1638,7 @@ class AnophelesDataResource(ABC):
         debug = self._log.debug
 
         debug("normalise parameters")
-        sample_sets = self._prep_sample_sets_arg(sample_sets=sample_sets)
+        sample_sets = self._prep_sample_sets_param(sample_sets=sample_sets)
         region = self.resolve_region(region)
 
         debug("normalise region to list to simplify concatenation logic")
@@ -2036,7 +2036,7 @@ class AnophelesDataResource(ABC):
         debug = self._log.debug
 
         debug("normalise parameters")
-        sample_sets = self._prep_sample_sets_arg(sample_sets=sample_sets)
+        sample_sets = self._prep_sample_sets_param(sample_sets=sample_sets)
         region = self.resolve_region(region)
         if isinstance(region, Region):
             region = [region]
@@ -3905,7 +3905,7 @@ class AnophelesDataResource(ABC):
             region=self.resolve_region(region).to_dict(),
             n_snps=n_snps,
             thin_offset=thin_offset,
-            sample_sets=self._prep_sample_sets_arg(sample_sets=sample_sets),
+            sample_sets=self._prep_sample_sets_param(sample_sets=sample_sets),
             sample_query=sample_query,
             site_mask=site_mask,
             min_minor_ac=min_minor_ac,
@@ -4496,7 +4496,7 @@ class AnophelesDataResource(ABC):
             A dataframe of cohort metadata, one row per sample.
 
         """
-        sample_sets = self._prep_sample_sets_arg(sample_sets=sample_sets)
+        sample_sets = self._prep_sample_sets_param(sample_sets=sample_sets)
 
         # concatenate multiple sample sets
         dfs = [self._read_cohort_metadata(sample_set=s) for s in sample_sets]
@@ -5300,7 +5300,7 @@ class AnophelesDataResource(ABC):
             window_size=window_size,
             cohort1_query=cohort1_query,
             cohort2_query=cohort2_query,
-            sample_sets=self._prep_sample_sets_arg(sample_sets=sample_sets),
+            sample_sets=self._prep_sample_sets_param(sample_sets=sample_sets),
             site_mask=site_mask,
             cohort_size=cohort_size,
             random_seed=random_seed,
@@ -6659,7 +6659,7 @@ class AnophelesDataResource(ABC):
         debug = self._log.debug
 
         debug("normalise parameters")
-        sample_sets = self._prep_sample_sets_arg(sample_sets=sample_sets)
+        sample_sets = self._prep_sample_sets_param(sample_sets=sample_sets)
         region = self.resolve_region(region)
         if isinstance(region, Region):
             region = [region]
@@ -6781,7 +6781,7 @@ class AnophelesDataResource(ABC):
             contig=contig,
             analysis=self._prep_phasing_analysis_param(analysis=analysis),
             window_sizes=window_sizes,
-            sample_sets=self._prep_sample_sets_arg(sample_sets=sample_sets),
+            sample_sets=self._prep_sample_sets_param(sample_sets=sample_sets),
             sample_query=sample_query,
             cohort_size=cohort_size,
             random_seed=random_seed,
@@ -6978,7 +6978,7 @@ class AnophelesDataResource(ABC):
             contig=contig,
             analysis=self._prep_phasing_analysis_param(analysis=analysis),
             window_size=window_size,
-            sample_sets=self._prep_sample_sets_arg(sample_sets=sample_sets),
+            sample_sets=self._prep_sample_sets_param(sample_sets=sample_sets),
             sample_query=sample_query,
             cohort_size=cohort_size,
             random_seed=random_seed,
@@ -7295,7 +7295,7 @@ class AnophelesDataResource(ABC):
             window_size=window_size,
             cohort1_query=cohort1_query,
             cohort2_query=cohort2_query,
-            sample_sets=self._prep_sample_sets_arg(sample_sets=sample_sets),
+            sample_sets=self._prep_sample_sets_param(sample_sets=sample_sets),
             cohort_size=cohort_size,
             random_seed=random_seed,
         )

--- a/malariagen_data/anopheles.py
+++ b/malariagen_data/anopheles.py
@@ -283,6 +283,21 @@ class AnophelesDataResource(ABC):
         raise NotImplementedError("Must override _fst_gwss_results_cache_name")
 
     @property
+    @abstractmethod
+    def _h12_calibration_cache_name(self):
+        raise NotImplementedError("Must override _h12_calibration_cache_name")
+
+    @property
+    @abstractmethod
+    def _h12_gwss_cache_name(self):
+        raise NotImplementedError("Must override _h12_gwss_cache_name")
+
+    @property
+    @abstractmethod
+    def _h1x_gwss_cache_name(self):
+        raise NotImplementedError("Must override _h1x_gwss_cache_name")
+
+    @property
     def _geneset_gff3_path(self):
         return self._config.get("GENESET_GFF3_PATH")
 
@@ -742,7 +757,7 @@ class AnophelesDataResource(ABC):
 
     @staticmethod
     @abstractmethod
-    def _setup_taxon_colors(plot_kwargs):
+    def _setup_taxon_colors(plot_kwargs=None):
         # Subclasses have different taxon_color_map.
         raise NotImplementedError("Must override _setup_taxon_colors")
 

--- a/malariagen_data/anopheles.py
+++ b/malariagen_data/anopheles.py
@@ -341,9 +341,12 @@ class AnophelesDataResource(ABC):
         raise NotImplementedError("Must override _default_site_mask")
 
     def _prep_site_mask_param(self, *, site_mask):
-        if site_mask == DEFAULT:
+        if site_mask is None:
+            # allowed
+            pass
+        elif site_mask == DEFAULT:
             site_mask = self._default_site_mask
-        if site_mask not in self.site_mask_ids:
+        elif site_mask not in self.site_mask_ids:
             raise ValueError(
                 f"Invalid site mask, must be one of f{self.site_mask_ids}."
             )
@@ -457,8 +460,9 @@ class AnophelesDataResource(ABC):
         sample_query : str, optional
             A pandas query string which will be evaluated against the sample
             metadata e.g., "taxon == 'coluzzii' and country == 'Burkina Faso'".
-        site_mask : {"gamb_colu_arab", "gamb_colu", "arab"}
-            Site filters mask to apply.
+        site_mask : str, optional
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         site_class : str, optional
             Select sites belonging to one of the following classes: CDS_DEG_4,
             (4-fold degenerate coding sites), CDS_DEG_2_SIMPLE (2-fold simple
@@ -506,7 +510,7 @@ class AnophelesDataResource(ABC):
             region=self.resolve_region(region).to_dict(),
             sample_sets=self._prep_sample_sets_param(sample_sets=sample_sets),
             sample_query=sample_query,
-            site_mask=site_mask,
+            site_mask=self._prep_site_mask_param(site_mask=site_mask),
             site_class=site_class,
             cohort_size=cohort_size,
             random_seed=random_seed,
@@ -564,7 +568,8 @@ class AnophelesDataResource(ABC):
             dropped from the result.
         variant_query : str, optional
         site_mask : str, optional
-            Site filters mask to apply.
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         nobs_mode : {"called", "fixed"}
             Method for calculating the denominator when computing frequencies.
             If "called" then use the number of called alleles, i.e., number of
@@ -1514,7 +1519,8 @@ class AnophelesDataResource(ABC):
         field : {"POS", "REF", "ALT"}
             Array to access.
         site_mask : str, optional
-            Site filters mask to apply, e.g. "gamb_colu"
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         inline_array : bool, optional
             Passed through to dask.array.from_array().
         chunks : str, optional
@@ -1650,7 +1656,8 @@ class AnophelesDataResource(ABC):
         field : {"GT", "GQ", "AD", "MQ"}
             Array to access.
         site_mask : str, optional
-            Site filters mask to apply, e.g. "gamb_colu"
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         inline_array : bool, optional
             Passed through to dask.array.from_array().
         chunks : str, optional
@@ -1778,7 +1785,7 @@ class AnophelesDataResource(ABC):
     def is_accessible(
         self,
         region,
-        site_mask,
+        site_mask=DEFAULT,
     ):
         """Compute genome accessibility array.
 
@@ -1790,8 +1797,9 @@ class AnophelesDataResource(ABC):
             named tuple with genomic location `Region(contig, start, end)`.
             Multiple values can be provided as a list, in which case data will
             be concatenated, e.g., ["3R", "3L"].
-        site_mask : str
-            Site filters mask to apply, e.g. "gamb_colu"
+        site_mask : str, optional
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
 
         Returns
         -------
@@ -1892,7 +1900,8 @@ class AnophelesDataResource(ABC):
         transcript : str
             Gene transcript ID (AgamP4.12), e.g., "AGAP004707-RA".
         site_mask : str, optional
-            Site filters mask to apply, e.g. "gamb_colu"
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
 
         Returns
         -------
@@ -2035,7 +2044,8 @@ class AnophelesDataResource(ABC):
             A pandas query string which will be evaluated against the sample
             metadata e.g., "country == 'Burkina Faso'".
         site_mask : str, optional
-            Site filters mask to apply, e.g. "gamb_colu"
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         site_class : str, optional
             Select sites belonging to one of the following classes: CDS_DEG_4,
             (4-fold degenerate coding sites), CDS_DEG_2_SIMPLE (2-fold simple
@@ -2352,7 +2362,8 @@ class AnophelesDataResource(ABC):
             Multiple values can be provided as a list, in which case data will
             be concatenated, e.g., ["3R", "3L"].
         site_mask : str, optional
-            Site filters mask to apply, e.g. "gamb_colu"
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         inline_array : bool, optional
             Passed through to dask.array.from_array().
         chunks : str, optional
@@ -3055,7 +3066,8 @@ class AnophelesDataResource(ABC):
             genomic region defined with coordinates (e.g.,
             "2L:44989425-44998059").
         site_mask : str, optional
-            Site filters mask to apply, e.g. "gamb_colu"
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         window_size : int, optional
             Number of sites per window.
         sample_set : str, optional
@@ -3139,7 +3151,8 @@ class AnophelesDataResource(ABC):
             genomic region defined with coordinates (e.g.,
             "2L:44989425-44998059").
         site_mask : str, optional
-            Site filters mask to apply, e.g. "gamb_colu"
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         window_size : int, optional
             Number of sites per window.
         sample_set : str, optional
@@ -3313,7 +3326,8 @@ class AnophelesDataResource(ABC):
         window_size : int, optional
             Number of sites per window.
         site_mask : str, optional
-            Site filters mask to apply, e.g. "gamb_colu"
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         sample_set : str, optional
             Sample set identifier. Not needed if sample parameter gives a sample
             identifier.
@@ -3472,7 +3486,8 @@ class AnophelesDataResource(ABC):
         window_size : int, optional
             Number of sites per window.
         site_mask : str, optional
-            Site filters mask to apply, e.g. "gamb_colu"
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         sample_set : str, optional
             Sample set identifier. Not needed if sample parameter gives a sample
             identifier.
@@ -3758,8 +3773,9 @@ class AnophelesDataResource(ABC):
             named tuple with genomic location `Region(contig, start, end)`.
             Multiple values can be provided as a list, in which case data will
             be concatenated, e.g., ["3R", "3L"].
-        site_mask : str
-            Site filters mask to apply, e.g. "gamb_colu"
+        site_mask : str, optional
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         inline_array : bool, optional
             Passed through to dask.from_array().
         chunks : str, optional
@@ -3893,7 +3909,8 @@ class AnophelesDataResource(ABC):
             A pandas query string which will be evaluated against the sample
             metadata e.g., "country == 'Burkina Faso'".
         site_mask : str, optional
-            Site filters mask to apply, e.g. "gamb_colu"
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         min_minor_ac : int, optional
             The minimum minor allele count. SNPs with a minor allele count
             below this value will be excluded prior to thinning.
@@ -3994,7 +4011,8 @@ class AnophelesDataResource(ABC):
             A pandas query string which will be evaluated against the sample
             metadata e.g., "country == 'Burkina Faso'".
         site_mask : str, optional
-            Site filters mask to apply, e.g. "gamb_colu".
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         cohort_size : int, optional
             If provided, randomly down-sample to the given cohort size before
             computing allele counts.
@@ -4107,7 +4125,8 @@ class AnophelesDataResource(ABC):
             A pandas query string which will be evaluated against the sample
             metadata e.g., "country == 'Burkina Faso'".
         site_mask : str, optional
-            Site filters mask to apply, e.g. "gamb_colu".
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         cohort_size : int, optional
             If provided, randomly down-sample to the given cohort size before
             computing allele counts.
@@ -4315,7 +4334,8 @@ class AnophelesDataResource(ABC):
         min_cohort_size : int
             Minimum cohort size. Any cohorts below this size are omitted.
         site_mask : str, optional
-            Site filters mask to apply.
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         sample_sets : str or list of str, optional
             Can be a sample set identifier (e.g., "AG1000G-AO") or a list of
             sample set identifiers (e.g., ["AG1000G-BF-A", "AG1000G-BF-B"]) or a
@@ -4554,7 +4574,8 @@ class AnophelesDataResource(ABC):
             Minimum cohort size, below which allele frequencies are not
             calculated for cohorts.
         site_mask : str, optional
-            Site filters mask to apply.
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         sample_sets : str or list of str, optional
             Can be a sample set identifier (e.g., "AG1000G-AO") or a list of
             sample set identifiers (e.g., ["AG1000G-BF-A", "AG1000G-BF-B"]) or a
@@ -4679,7 +4700,8 @@ class AnophelesDataResource(ABC):
             Minimum cohort size. Any cohorts below this size are omitted.
         variant_query : str, optional
         site_mask : str, optional
-            Site filters mask to apply.
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         nobs_mode : {"called", "fixed"}
             Method for calculating the denominator when computing frequencies.
             If "called" then use the number of called alleles, i.e., number of
@@ -4941,7 +4963,7 @@ class AnophelesDataResource(ABC):
         cohort,
         cohort_size,
         region,
-        site_mask,
+        site_mask=DEFAULT,
         site_class=None,
         sample_sets=None,
         random_seed=42,
@@ -4965,8 +4987,9 @@ class AnophelesDataResource(ABC):
             Chromosome arm, gene name or
             genomic region defined with coordinates (e.g.,
             "2L:44989425-44998059").
-        site_mask : str
-            Site filters mask to apply.
+        site_mask : str, optional
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         site_class : str, optional
             Select sites belonging to one of the following classes: CDS_DEG_4,
             (4-fold degenerate coding sites), CDS_DEG_2_SIMPLE (2-fold simple
@@ -5080,7 +5103,7 @@ class AnophelesDataResource(ABC):
         cohorts,
         cohort_size,
         region,
-        site_mask,
+        site_mask=DEFAULT,
         site_class=None,
         sample_query=None,
         sample_sets=None,
@@ -5103,8 +5126,9 @@ class AnophelesDataResource(ABC):
             Chromosome arm (e.g., "2L"), gene name (e.g., "AGAP007280") or
             genomic region defined with coordinates (e.g.,
             "2L:44989425-44998059").
-        site_mask : {"gamb_colu_arab", "gamb_colu", "arab"}
-            Site filters mask to apply.
+        site_mask : str, optional
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         site_class : str, optional
             Select sites belonging to one of the following classes: CDS_DEG_4,
             (4-fold degenerate coding sites), CDS_DEG_2_SIMPLE (2-fold simple
@@ -5294,8 +5318,9 @@ class AnophelesDataResource(ABC):
             Can be a sample set identifier (e.g., "AG1000G-AO") or a list of
             sample set identifiers (e.g., ["AG1000G-BF-A", "AG1000G-BF-B"]) or a
             release identifier (e.g., "3.0") or a list of release identifiers.
-        site_mask : {"gamb_colu_arab", "gamb_colu", "arab"}, optional
-            Site filters mask to apply.
+        site_mask : str, optional
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         cohort_size : int, optional
             If provided, randomly down-sample to the given cohort size.
         random_seed : int, optional
@@ -6324,7 +6349,8 @@ class AnophelesDataResource(ABC):
             sample set identifiers or a
             release identifier or a list of release identifiers.
         site_mask : str, optional
-            Site filters mask to apply.
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         cohort_size : int, optional
             If provided, randomly down-sample to the given cohort size.
         random_seed : int, optional
@@ -6442,7 +6468,8 @@ class AnophelesDataResource(ABC):
             sample set identifiers or a
             release identifier or a list of release identifiers.
         site_mask : str, optional
-            Site filters mask to apply.
+            Which site filters mask to apply. See the `site_mask_ids`
+            property for available values.
         cohort_size : int, optional
             If provided, randomly down-sample to the given cohort size.
         random_seed : int, optional

--- a/tests/test_ag3.py
+++ b/tests/test_ag3.py
@@ -2907,66 +2907,6 @@ def test_h1x_gwss():
     assert np.all(h1x >= 0)
 
 
-def test_haplotype_frequencies():
-    h1 = np.array(
-        [
-            [0, 1, 1, 1, 0],
-            [0, 1, 0, 0, 0],
-            [1, 0, 1, 1, 0],
-            [0, 1, 1, 1, 0],
-            [0, 0, 1, 1, 0],
-            [1, 1, 0, 0, 0],
-            [0, 1, 1, 1, 0],
-        ],
-        dtype="i1",
-    )
-    from malariagen_data.ag3 import _haplotype_frequencies
-
-    f = _haplotype_frequencies(h1)
-    assert isinstance(f, dict)
-    vals = np.array(list(f.values()))
-    vals.sort()
-    assert np.all(vals >= 0)
-    assert np.all(vals <= 1)
-    assert_allclose(vals, np.array([0.2, 0.2, 0.2, 0.4]))
-
-
-def test_haplotype_joint_frequencies():
-    h1 = np.array(
-        [
-            [0, 1, 1, 1, 0],
-            [0, 1, 0, 0, 0],
-            [1, 0, 1, 1, 0],
-            [0, 1, 1, 1, 0],
-            [0, 0, 1, 1, 0],
-            [1, 1, 0, 0, 0],
-            [0, 1, 1, 1, 0],
-        ],
-        dtype="i1",
-    )
-    h2 = np.array(
-        [
-            [0, 1, 1, 1, 0],
-            [1, 1, 0, 0, 0],
-            [1, 0, 1, 1, 1],
-            [0, 1, 1, 1, 0],
-            [0, 0, 1, 1, 0],
-            [1, 1, 0, 0, 0],
-            [0, 1, 1, 1, 0],
-        ],
-        dtype="i1",
-    )
-    from malariagen_data.ag3 import _haplotype_joint_frequencies
-
-    f = _haplotype_joint_frequencies(h1, h2)
-    assert isinstance(f, dict)
-    vals = np.array(list(f.values()))
-    vals.sort()
-    assert np.all(vals >= 0)
-    assert np.all(vals <= 1)
-    assert_allclose(vals, np.array([0, 0, 0, 0, 0.04, 0.16]))
-
-
 def test_fst_gwss():
     ag3 = setup_ag3()
     cohort1_query = "cohort_admin2_year == 'ML-2_Kati_colu_2014'"


### PR DESCRIPTION
Hi @leehart, some tidying up of internals here for consistency...

* Rename sample set argument preparation function for consistency
* Handle site_mask the same way as phasing analysis
* Standardise site_mask parameter docs
* Make site_mask parameter always optional with default
* Add missing abstract properties
* Move haplotype frequency tests